### PR TITLE
Add tests for LIC1

### DIFF
--- a/src/test/java/com/decide/DecideTest.java
+++ b/src/test/java/com/decide/DecideTest.java
@@ -107,31 +107,3 @@ public class DecideTest{
         assertFalse(res);
     }
 }
-
-/**
- *     @Test
-    public void LIC13TestPositive() {
-        double[] x = {7.2, 12.8, 5.6, 15.5, 15.3, 12.1, 19.6, 8.9};
-        double[] y = {6.2, 12.5, 12, 6.3, 1.4, 6.4, 13.1, 15.5};
-        // The points (5.6, 12), (15.3, 1.4), (8.9, 15.5) cannot be contained in a circle with radius 7.6 (Only two of the points).
-        // The points (12.8, 12.5), (15.5, 6.3), (19.6, 13.1) can just about be contained in a circle with radius 4.25.
-        double r1 = 7.6, r2 = 4.25;
-        boolean res = DEFAULT.LIC13(x.length, x, y, 1, 2, r1, r2);
-        assertTrue(res);
-    }
-
-    @Test
-    public void LIC13TestNegative() {
-        double[] x = {7.2, 12.8, 5.6, 15.5, 15.3, 12.1, 19.6, 8.9};
-        double[] y = {6.2, 12.5, 12, 6.3, 1.4, 6.4, 13.1, 15.5};
-        double r1 = 7.9, r2 = 4.25;
-        // This should return false since all sets of three points can now be contained in the circle with radius 7.9.
-        boolean res = DEFAULT.LIC13(x.length, x, y, 1, 2, r1, r2);
-        assertFalse(res);
-
-        r1 = 7.6; r2 = 4.15;
-        // This should also return false since no set of points can be contained in the circle with radius 4.15.
-        res = DEFAULT.LIC13(x.length, x, y, 1, 2, r1, r2);
-        assertFalse(res);
-    }
- */


### PR DESCRIPTION
Fix #4 

Add two basic tests for LIC1.
They don't seem to work which suggests a bug in the implementation.

They should pass after issue #30 is fixed.